### PR TITLE
add browser option

### DIFF
--- a/src/get-rollup-options.js
+++ b/src/get-rollup-options.js
@@ -70,7 +70,8 @@ export default function (options, format) {
     plugins.push(
       require('rollup-plugin-node-resolve')({
         skip: options.skip,
-        jsnext: options.jsnext
+        jsnext: options.jsnext,
+        browser: options.browser
       }),
       require('rollup-plugin-commonjs')()
     )


### PR DESCRIPTION
Add support for rollup-plugin-node-resolve's `browser` option to be able to take a package.json's `browser` field into account